### PR TITLE
O evento "document.ready" do javascript "pagarme" estava ocorrendo ap…

### DIFF
--- a/app/assets/javascripts/pagarme.js.erb
+++ b/app/assets/javascripts/pagarme.js.erb
@@ -1,6 +1,12 @@
 $(document).ready(function() {
   
-   $("#new_payment").submit(function(event) {
+   $(document).submit(function(event) {
+    if (!($('meta[name=psj]').attr('controller') == 'payments' && $('meta[name=psj]').attr('action') == 'new')) {
+
+      return
+    }
+    
+    
     event.preventDefault();
 
     var card = {}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,9 +5,10 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <%= tag :meta, name: :psj, action: action_name, controller: controller_name%>
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-
+ 
     <script src="https://assets.pagar.me/pagarme-js/3.0/pagarme.min.js"></script>
   </head>
 


### PR DESCRIPTION
…enas na primeira vez que a página carregava (tipicamente no dashboard). Portanto, o evento de submit do form de novo pagamento só era sobrescrito se a gente desse um F5 na página de novo pagamento

Solução:
1) alterar o layout da aplicação pra incluir o nome do controller e da ação no header da página
2) editar o javascript do pagarme para sobrescrever o evento de submit de qualquer form, e verificar dentro do método qual é o controller e action atual